### PR TITLE
Cleanup macro code

### DIFF
--- a/yarrow_derive/Cargo.toml
+++ b/yarrow_derive/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro = true
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
+proc-macro-crate = "3.1.0"

--- a/yarrow_derive/src/lib.rs
+++ b/yarrow_derive/src/lib.rs
@@ -1,6 +1,18 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
+use proc_macro_crate::crate_name;
 use quote::quote;
-use syn::{parse::Parser, parse_macro_input, spanned::Spanned, DeriveInput};
+use syn::{parse::Parser, parse_macro_input, spanned::Spanned, DeriveInput, Ident};
+
+fn root() -> proc_macro2::TokenStream {
+    match crate_name("yarrow").expect("yarrow not found in Cargo.toml") {
+        proc_macro_crate::FoundCrate::Itself => quote! { crate },
+        proc_macro_crate::FoundCrate::Name(name) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote! { ::#ident }
+        }
+    }
+}
 
 #[proc_macro_attribute]
 pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
@@ -8,6 +20,8 @@ pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
     let name = ast.ident.clone();
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let crate_name = root();
 
     match &mut ast.data {
         syn::Data::Struct(ref mut struct_data) => {
@@ -19,7 +33,7 @@ pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
                             ///
                             /// If this method is not used, then the current z index from the window context will
                             /// be used.
-                            pub z_index: Option<ZIndex>
+                            pub z_index: Option<#crate_name::math::ZIndex>
                         })
                         .unwrap(),
                 );
@@ -31,7 +45,7 @@ pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
                             ///
                             /// If this method is not used, then the current scissoring rectangle ID from the
                             /// window context will be used.
-                            pub scissor_rect: Option<ScissorRectID>
+                            pub scissor_rect: Option<#crate_name::ScissorRectID>
                         })
                         .unwrap(),
                 );
@@ -45,7 +59,7 @@ pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
                     ///
                     /// If this method is not used, then the current z index from the window context will
                     /// be used.
-                    pub const fn z_index(mut self, z_index: ZIndex) -> Self {
+                    pub const fn z_index(mut self, z_index: #crate_name::math::ZIndex) -> Self {
                         self.z_index = Some(z_index);
                         self
                     }
@@ -54,7 +68,7 @@ pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
                     ///
                     /// If this method is not used, then the current scissoring rectangle ID from the
                     /// window context will be used.
-                    pub const fn scissor_rect(mut self, scissor_rect: ScissorRectID) -> Self {
+                    pub const fn scissor_rect(mut self, scissor_rect: #crate_name::ScissorRectID) -> Self {
                         self.scissor_rect = Some(scissor_rect);
                         self
                     }
@@ -75,6 +89,8 @@ pub fn element_builder_class(_args: TokenStream, input: TokenStream) -> TokenStr
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let crate_name = root();
+
     match &mut ast.data {
         syn::Data::Struct(ref mut struct_data) => {
             if let syn::Fields::Named(ref mut fields) = struct_data.fields {
@@ -85,7 +101,7 @@ pub fn element_builder_class(_args: TokenStream, input: TokenStream) -> TokenStr
                             ///
                             /// If this method is not used, then the current class from the window context will
                             /// be used.
-                            pub class: Option<ClassID>
+                            pub class: Option<#crate_name::style::ClassID>
                         })
                         .unwrap(),
                 );
@@ -99,7 +115,7 @@ pub fn element_builder_class(_args: TokenStream, input: TokenStream) -> TokenStr
                     ///
                     /// If this method is not used, then the current class from the window context will
                     /// be used.
-                    pub const fn class(mut self, class: ClassID) -> Self {
+                    pub const fn class(mut self, class: #crate_name::style::ClassID) -> Self {
                         self.class = Some(class);
                         self
                     }
@@ -123,6 +139,8 @@ pub fn element_builder_rect(_args: TokenStream, input: TokenStream) -> TokenStre
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let crate_name = root();
+
     match &mut ast.data {
         syn::Data::Struct(ref mut struct_data) => {
             if let syn::Fields::Named(ref mut fields) = struct_data.fields {
@@ -133,7 +151,7 @@ pub fn element_builder_rect(_args: TokenStream, input: TokenStream) -> TokenStre
                             ///
                             /// If this method is not used, then the element will have a size and position of
                             /// zero and will not be visible until its bounding rectangle is set.
-                            pub rect: ::rootvg::math::Rect
+                            pub rect: #crate_name::math::Rect
                         })
                         .unwrap(),
                 );
@@ -147,7 +165,7 @@ pub fn element_builder_rect(_args: TokenStream, input: TokenStream) -> TokenStre
                     ///
                     /// If this method is not used, then the element will have a size and position of
                     /// zero and will not be visible until its bounding rectangle is set.
-                    pub const fn rect(mut self, rect: ::rootvg::math::Rect) -> Self {
+                    pub const fn rect(mut self, rect: #crate_name::math::Rect) -> Self {
                         self.rect = rect;
                         self
                     }
@@ -263,6 +281,8 @@ pub fn element_builder_tooltip(_args: TokenStream, input: TokenStream) -> TokenS
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let crate_name = root();
+
     match &mut ast.data {
         syn::Data::Struct(ref mut struct_data) => {
             if let syn::Fields::Named(ref mut fields) = struct_data.fields {
@@ -274,7 +294,7 @@ pub fn element_builder_tooltip(_args: TokenStream, input: TokenStream) -> TokenS
                             /// If this is `None` then this element will not have a tooltip.
                             ///
                             /// By default this is set to `None`.
-                            pub tooltip_data: Option<TooltipData>
+                            pub tooltip_data: Option<#crate_name::elements::tooltip::TooltipData>
                         })
                         .unwrap(),
                 );
@@ -288,8 +308,8 @@ pub fn element_builder_tooltip(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// * `text` - The tooltip text
                     /// * `align` - Where to align the tooltip relative to this element
-                    pub fn tooltip(mut self, text: impl Into<String>, align: Align2) -> Self {
-                        self.tooltip_data = Some(TooltipData::new(text, align));
+                    pub fn tooltip(mut self, text: impl Into<String>, align: #crate_name::layout::Align2) -> Self {
+                        self.tooltip_data = Some(#crate_name::elements::tooltip::TooltipData::new(text, align));
                         self
                     }
                 }
@@ -312,13 +332,15 @@ pub fn element_handle(_args: TokenStream, input: TokenStream) -> TokenStream {
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let crate_name = root();
+
     match &mut ast.data {
         syn::Data::Struct(ref mut struct_data) => {
             if let syn::Fields::Named(ref mut fields) = struct_data.fields {
                 fields.named.push(
                     syn::Field::parse_named
                         .parse2(quote! {
-                            el: ElementHandle
+                            el: #crate_name::prelude::ElementHandle
                         })
                         .unwrap(),
                 );
@@ -331,28 +353,28 @@ pub fn element_handle(_args: TokenStream, input: TokenStream) -> TokenStream {
                     /// Get the bounding rectangle of this element instance.
                     ///
                     /// This is cached directly in the handle so this is very cheap to call frequently.
-                    pub fn rect(&self) -> Rect {
+                    pub fn rect(&self) -> #crate_name::math::Rect {
                         self.el.rect()
                     }
 
                     /// Get the top-left position of the bounding rectangle of this element instance.
                     ///
                     /// This is cached directly in the handle so this is very cheap to call frequently.
-                    pub fn origin(&self) -> Point {
+                    pub fn origin(&self) -> #crate_name::math::Point {
                         self.el.rect().origin
                     }
 
                     /// Get the bottom-right position of the bounding rectangle of this element instance.
                     ///
                     /// This is cached directly in the handle so this is very cheap to call frequently.
-                    pub fn max(&self) -> Point {
+                    pub fn max(&self) -> #crate_name::math::Point {
                         self.el.rect().max()
                     }
 
                     /// Get the center position of the bounding rectangle of this element instance.
                     ///
                     /// This is cached directly in the handle so this is very cheap to call frequently.
-                    pub fn center(&self) -> Point {
+                    pub fn center(&self) -> #crate_name::math::Point {
                         self.el.rect().center()
                     }
 
@@ -408,7 +430,7 @@ pub fn element_handle(_args: TokenStream, input: TokenStream) -> TokenStream {
                     /// Get the z index of this element instance.
                     ///
                     /// This is cached directly in the handle so this is very cheap to call frequently.
-                    pub fn z_index(&self) -> ZIndex {
+                    pub fn z_index(&self) -> #crate_name::math::ZIndex {
                         self.el.z_index()
                     }
 
@@ -452,7 +474,7 @@ pub fn element_handle(_args: TokenStream, input: TokenStream) -> TokenStream {
 
                     /// Get the actual bounding rectangle of this element, accounting for the offset
                     /// introduced by its assigned scissoring rectangle.
-                    pub fn rect_in_window<A_: Clone + 'static>(&self, cx: &WindowContext<'_, A_>) -> Rect {
+                    pub fn rect_in_window<A_: Clone + 'static>(&self, cx: &#crate_name::WindowContext<'_, A_>) -> Rect {
                         self.el.rect_in_window(cx)
                     }
                 }
@@ -472,6 +494,8 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let crate_name = root();
+
     match &ast.data {
         syn::Data::Struct(_) => {
             quote! {
@@ -486,7 +510,7 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is very cheap to call frequently.
-                    pub fn set_rect(&mut self, rect: ::rootvg::math::Rect) -> bool {
+                    pub fn set_rect(&mut self, rect: #crate_name::math::Rect) -> bool {
                         self.el.set_rect(rect)
                     }
 
@@ -501,7 +525,7 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is very cheap to call frequently.
-                    pub fn set_pos(&mut self, pos: ::rootvg::math::Point) -> bool {
+                    pub fn set_pos(&mut self, pos: #crate_name::math::Point) -> bool {
                         self.el.set_pos(pos)
                     }
 
@@ -516,7 +540,7 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is very cheap to call frequently.
-                    pub fn set_size(&mut self, size: ::rootvg::math::Size) -> bool {
+                    pub fn set_size(&mut self, size: #crate_name::math::Size) -> bool {
                         self.el.set_size(size)
                     }
 
@@ -588,7 +612,7 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// Note, this will *always* cause an element update even if the offset
                     /// is zero, so prefer to call this method sparingly.
-                    pub fn offset_pos(&mut self, offset: ::rootvg::math::Vector) {
+                    pub fn offset_pos(&mut self, offset: #crate_name::math::Vector) {
                         self.el.offset_pos(offset)
                     }
                 }
@@ -611,6 +635,8 @@ pub fn element_handle_class(_args: TokenStream, input: TokenStream) -> TokenStre
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let crate_name = root();
+
     match &ast.data {
         syn::Data::Struct(_) => {
             quote! {
@@ -620,7 +646,7 @@ pub fn element_handle_class(_args: TokenStream, input: TokenStream) -> TokenStre
                     /// The current style class of the element.
                     ///
                     /// This is cached directly in the handle so this is very cheap to call frequently.
-                    pub fn class(&self) -> ClassID {
+                    pub fn class(&self) -> #crate_name::style::ClassID {
                         self.el.class()
                     }
 
@@ -631,7 +657,7 @@ pub fn element_handle_class(_args: TokenStream, input: TokenStream) -> TokenStre
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// and the class ID is cached in the handle itself, so this is relatively
                     /// cheap to call frequently (although a String comparison is performed).
-                    pub fn set_class(&mut self, class: ClassID) -> bool {
+                    pub fn set_class(&mut self, class: #crate_name::style::ClassID) -> bool {
                         self.el.set_class(class)
                     }
                 }
@@ -654,6 +680,8 @@ pub fn element_handle_layout_aligned(_args: TokenStream, input: TokenStream) -> 
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let crate_name = root();
+
     match &ast.data {
         syn::Data::Struct(_) => {
             quote! {
@@ -666,7 +694,7 @@ pub fn element_handle_layout_aligned(_args: TokenStream, input: TokenStream) -> 
                     ///
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is relatively cheap to call frequently.
-                    pub fn layout_aligned(&mut self, size: ::rootvg::math::Size, point: ::rootvg::math::Point, align: Align2) -> bool {
+                    pub fn layout_aligned(&mut self, size: #crate_name::math::Size, point: #crate_name::math::Point, align: #crate_name::layout::Align2) -> bool {
                         self.el.set_rect(align.align_rect_to_point(point, size))
                     }
                 }
@@ -689,6 +717,8 @@ pub fn element_handle_set_tooltip(_args: TokenStream, input: TokenStream) -> Tok
     let generics = ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let crate_name = root();
+
     match &ast.data {
         syn::Data::Struct(_) => {
             quote! {
@@ -705,7 +735,7 @@ pub fn element_handle_set_tooltip(_args: TokenStream, input: TokenStream) -> Tok
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is relatively cheap to call frequently (although a string
                     /// comparison is performed).
-                    pub fn set_tooltip(mut self, text: Option<&str>, align: Align2) -> bool {
+                    pub fn set_tooltip(mut self, text: Option<&str>, align: #crate_name::layout::Align2) -> bool {
                         if RefCell::borrow_mut(&self.shared_state).tooltip_inner.set_data(text, align) {
                             self.el.notify_custom_state_change();
                             true

--- a/yarrow_derive/src/lib.rs
+++ b/yarrow_derive/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse::Parser, parse_macro_input, DeriveInput};
+use syn::{parse::Parser, parse_macro_input, spanned::Spanned, DeriveInput};
 
 #[proc_macro_attribute]
 pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
@@ -37,7 +37,7 @@ pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
                 );
             }
 
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -60,9 +60,11 @@ pub fn element_builder(_args: TokenStream, input: TokenStream) -> TokenStream {
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_builder` has to be used with structs "),
+        _ => syn::Error::new(ast.span(), "`element_builder` has to be used with structs")
+            .to_compile_error()
+            .into(),
     }
 }
 
@@ -89,7 +91,7 @@ pub fn element_builder_class(_args: TokenStream, input: TokenStream) -> TokenStr
                 );
             }
 
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -103,9 +105,14 @@ pub fn element_builder_class(_args: TokenStream, input: TokenStream) -> TokenStr
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_builder_class` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_builder_class` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }
 
@@ -126,13 +133,13 @@ pub fn element_builder_rect(_args: TokenStream, input: TokenStream) -> TokenStre
                             ///
                             /// If this method is not used, then the element will have a size and position of
                             /// zero and will not be visible until its bounding rectangle is set.
-                            pub rect: Rect
+                            pub rect: ::rootvg::math::Rect
                         })
                         .unwrap(),
                 );
             }
 
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -140,15 +147,20 @@ pub fn element_builder_rect(_args: TokenStream, input: TokenStream) -> TokenStre
                     ///
                     /// If this method is not used, then the element will have a size and position of
                     /// zero and will not be visible until its bounding rectangle is set.
-                    pub const fn rect(mut self, rect: Rect) -> Self {
+                    pub const fn rect(mut self, rect: ::rootvg::math::Rect) -> Self {
                         self.rect = rect;
                         self
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_builder_rect` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_builder_rect` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }
 
@@ -174,7 +186,7 @@ pub fn element_builder_hidden(_args: TokenStream, input: TokenStream) -> TokenSt
                 );
             }
 
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -187,9 +199,14 @@ pub fn element_builder_hidden(_args: TokenStream, input: TokenStream) -> TokenSt
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_builder_rect` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_builder_rect` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }
 
@@ -215,7 +232,7 @@ pub fn element_builder_disabled(_args: TokenStream, input: TokenStream) -> Token
                 );
             }
 
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -228,9 +245,14 @@ pub fn element_builder_disabled(_args: TokenStream, input: TokenStream) -> Token
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_builder_disabled` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_builder_disabled` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }
 
@@ -258,7 +280,7 @@ pub fn element_builder_tooltip(_args: TokenStream, input: TokenStream) -> TokenS
                 );
             }
 
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -272,9 +294,14 @@ pub fn element_builder_tooltip(_args: TokenStream, input: TokenStream) -> TokenS
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_builder_tooltip` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_builder_tooltip` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }
 
@@ -297,7 +324,7 @@ pub fn element_handle(_args: TokenStream, input: TokenStream) -> TokenStream {
                 );
             }
 
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -430,9 +457,11 @@ pub fn element_handle(_args: TokenStream, input: TokenStream) -> TokenStream {
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_handle` has to be used with structs "),
+        _ => syn::Error::new(ast.span(), "`element_handle` has to be used with structs ")
+            .to_compile_error()
+            .into(),
     }
 }
 
@@ -445,7 +474,7 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
 
     match &ast.data {
         syn::Data::Struct(_) => {
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -457,7 +486,7 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is very cheap to call frequently.
-                    pub fn set_rect(&mut self, rect: Rect) -> bool {
+                    pub fn set_rect(&mut self, rect: ::rootvg::math::Rect) -> bool {
                         self.el.set_rect(rect)
                     }
 
@@ -472,7 +501,7 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is very cheap to call frequently.
-                    pub fn set_pos(&mut self, pos: Point) -> bool {
+                    pub fn set_pos(&mut self, pos: ::rootvg::math::Point) -> bool {
                         self.el.set_pos(pos)
                     }
 
@@ -487,7 +516,7 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is very cheap to call frequently.
-                    pub fn set_size(&mut self, size: Size) -> bool {
+                    pub fn set_size(&mut self, size: ::rootvg::math::Size) -> bool {
                         self.el.set_size(size)
                     }
 
@@ -559,14 +588,19 @@ pub fn element_handle_set_rect(_args: TokenStream, input: TokenStream) -> TokenS
                     ///
                     /// Note, this will *always* cause an element update even if the offset
                     /// is zero, so prefer to call this method sparingly.
-                    pub fn offset_pos(&mut self, offset: Vector) {
+                    pub fn offset_pos(&mut self, offset: ::rootvg::math::Vector) {
                         self.el.offset_pos(offset)
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_handle_set_rect` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_handle_set_rect` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }
 
@@ -579,7 +613,7 @@ pub fn element_handle_class(_args: TokenStream, input: TokenStream) -> TokenStre
 
     match &ast.data {
         syn::Data::Struct(_) => {
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -602,9 +636,14 @@ pub fn element_handle_class(_args: TokenStream, input: TokenStream) -> TokenStre
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_handle_class` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_handle_class` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }
 
@@ -617,7 +656,7 @@ pub fn element_handle_layout_aligned(_args: TokenStream, input: TokenStream) -> 
 
     match &ast.data {
         syn::Data::Struct(_) => {
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -627,14 +666,19 @@ pub fn element_handle_layout_aligned(_args: TokenStream, input: TokenStream) -> 
                     ///
                     /// This will *NOT* trigger an element update unless the value has changed,
                     /// so this method is relatively cheap to call frequently.
-                    pub fn layout_aligned(&mut self, size: Size, point: Point, align: Align2) -> bool {
+                    pub fn layout_aligned(&mut self, size: ::rootvg::math::Size, point: ::rootvg::math::Point, align: Align2) -> bool {
                         self.el.set_rect(align.align_rect_to_point(point, size))
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_handle_layout_aligned` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_handle_layout_aligned` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }
 
@@ -647,7 +691,7 @@ pub fn element_handle_set_tooltip(_args: TokenStream, input: TokenStream) -> Tok
 
     match &ast.data {
         syn::Data::Struct(_) => {
-            return quote! {
+            quote! {
                 #ast
 
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -671,8 +715,13 @@ pub fn element_handle_set_tooltip(_args: TokenStream, input: TokenStream) -> Tok
                     }
                 }
             }
-            .into();
+            .into()
         }
-        _ => panic!("`element_handle_set_tooltip` has to be used with structs "),
+        _ => syn::Error::new(
+            ast.span(),
+            "`element_handle_set_tooltip` has to be used with structs ",
+        )
+        .to_compile_error()
+        .into(),
     }
 }


### PR DESCRIPTION
remove return expressions, use crate_name to avoid error badness, and emit proper compiler errors when appropriate